### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/cmheisel/project-status-dashboard.png?label=ready&title=Ready)](https://waffle.io/cmheisel/project-status-dashboard)
 [![Build Status](https://travis-ci.org/cmheisel/project-status-dashboard.svg?branch=master)](https://travis-ci.org/cmheisel/project-status-dashboard)
 [![Coverage Status](https://coveralls.io/repos/github/cmheisel/project-status-dashboard/badge.svg?branch=master)](https://coveralls.io/github/cmheisel/project-status-dashboard?branch=master)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/cmheisel/project-status-dashboard

This was requested by a real person (user cmheisel) on waffle.io, we're not trying to spam you.
